### PR TITLE
add neg and rsub dunder methods, and fix imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Node
 node_modules/
+
+# PyCharm
+.idea/

--- a/gaia_beet/api.py
+++ b/gaia_beet/api.py
@@ -3,7 +3,8 @@ __all__ = ["Gaia"]
 from dataclasses import dataclass
 from typing import Any, List
 
-from beet import Context, DensityFunction, Noise
+from beet import Context
+from beet.contrib.worldgen import WorldgenDensityFunction, WorldgenNoise
 
 from .density_functions import DensityFunction as DF
 from .density_functions import ref
@@ -20,7 +21,7 @@ class Gaia:
         return f"{self.default_namespace}:{id}"
 
     def noise(self, id: str, first_octave: float, amplitudes: List[float]):
-        self.ctx.data[self.__id(id)] = Noise(
+        self.ctx.data[self.__id(id)] = WorldgenNoise(
             dict(
                 firstOctave=first_octave,
                 amplitudes=amplitudes,
@@ -31,5 +32,5 @@ class Gaia:
     def df(self, id: str, function: DF):
         with self.ctx.override(gaia_default_namespace=self.default_namespace):
             content: Any = function.generate(self.ctx)
-            self.ctx.data[self.__id(id)] = DensityFunction(content)
+            self.ctx.data[self.__id(id)] = WorldgenDensityFunction(content)
             return ref(self.__id(id))

--- a/gaia_beet/density_functions.py
+++ b/gaia_beet/density_functions.py
@@ -70,7 +70,7 @@ class DensityFunction:
         return TwoArgumentsDF("add", self, wrap(-other))
 
     def __rsub__(self, other: DensityFunctionInput):
-        return TwoArgumentsDF("add", wrap(-other), self)
+        return TwoArgumentsDF("add", wrap(other), -self)
 
     def __mul__(self, other: DensityFunctionInput):
         return TwoArgumentsDF("mul", self, wrap(other))

--- a/gaia_beet/density_functions.py
+++ b/gaia_beet/density_functions.py
@@ -63,10 +63,14 @@ class DensityFunction:
     def __radd__(self, other: DensityFunctionInput):
         return TwoArgumentsDF("add", wrap(other), self)
 
+    def __neg__(self):
+        return self * const(-1)
+
     def __sub__(self, other: DensityFunctionInput):
-        if isinstance(other, (int, float)):
-            return TwoArgumentsDF("add", self, wrap(-other))
-        return TwoArgumentsDF("add", self, wrap(other) * const(-1))
+        return TwoArgumentsDF("add", self, wrap(-other))
+
+    def __rsub__(self, other: DensityFunctionInput):
+        return TwoArgumentsDF("add", wrap(-other), self)
 
     def __mul__(self, other: DensityFunctionInput):
         return TwoArgumentsDF("mul", self, wrap(other))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "plugin-template",
+  "name": "gaia-beet",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
`__neg__` to allow writing `-df`. This also simplifies the implementation of `__sub__`.
`__rsub__` was also missing, this allows writing i.e. `1-df`

Finally, I guess some changes in beet require different imports of the worldgen plugin files.